### PR TITLE
feat(telegram): Issue #5 — Integración HTTP con Telegram Webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,13 @@ WEB_CHANNEL_TENANT_ID=inasc_web
 # CANALES DE MENSAJERÍA
 # ==========================================
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
+# ID del tenant para el canal Telegram (configurable por entorno)
+TELEGRAM_CHANNEL_TENANT_ID=inasc_telegram
+# Token secreto para validar que los POSTs vienen de Telegram (opcional pero recomendado en produccion)
+# Generarlo con: python -c "import secrets; print(secrets.token_hex(32))"
+# TELEGRAM_WEBHOOK_SECRET=your_webhook_secret_here
 # WHATSAPP_API_TOKEN=your_whatsapp_token_here
+
 
 # ==========================================
 # ENVÍO DE CORREOS (CRM / Handoff)

--- a/src/api/routers/telegram.py
+++ b/src/api/routers/telegram.py
@@ -1,0 +1,68 @@
+import logging
+import os
+from typing import Any, Dict
+
+from fastapi import APIRouter, Header, HTTPException, Request
+
+from src.core.producers.telegram_producer import TelegramProducer, TELEGRAM_TENANT_ID
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Telegram"])
+
+# Token secreto opcional para validar que los POSTs vienen realmente de Telegram.
+# Configurar en .env como TELEGRAM_WEBHOOK_SECRET.
+# Si no está definido, el endpoint acepta todos los requests (modo desarrollo).
+WEBHOOK_SECRET = os.getenv("TELEGRAM_WEBHOOK_SECRET", "")
+
+
+@router.post("/webhook/telegram")
+async def telegram_webhook(
+    request: Request,
+    x_telegram_bot_api_secret_token: str = Header(default=""),
+):
+    """
+    Endpoint que recibe los updates de Telegram via Webhook (push).
+
+    Flujo por cada update recibido:
+    1. Validar el token secreto (si TELEGRAM_WEBHOOK_SECRET está definido).
+    2. Parsear el body JSON del update.
+    3. Si no tiene 'message.text' → ignorar (fotos, stickers, comandos, etc.).
+    4. TelegramProducer normaliza el payload → IncomingMessage → Queue.
+    5. Responder 200 OK inmediatamente (Telegram requiere < 60s o reintenta).
+
+    IMPORTANTE: La respuesta al usuario se envía de forma asíncrona por
+    TelegramResponder en process_single_message(), NO en este endpoint.
+    """
+    # --- 1. Validación del token secreto (skip si no está configurado) ---
+    if WEBHOOK_SECRET and x_telegram_bot_api_secret_token != WEBHOOK_SECRET:
+        logger.warning(
+            "[TelegramWebhook] Token secreto inválido. Request rechazado."
+        )
+        raise HTTPException(status_code=403, detail="Invalid secret token")
+
+    # --- 2. Parsear el body ---
+    try:
+        update: Dict[str, Any] = await request.json()
+    except Exception:
+        logger.warning("[TelegramWebhook] Body JSON inválido.")
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    logger.info(f"[TelegramWebhook] Update recibido: update_id={update.get('update_id')}")
+
+    # --- 3. Ignorar updates sin 'message.text' ---
+    message = update.get("message", {})
+    if not message.get("text"):
+        logger.info("[TelegramWebhook] Update sin texto (foto, sticker, etc.) — ignorado.")
+        return {"ok": True}
+
+    # --- 4. Normalizar y enqueue ---
+    producer = TelegramProducer(tenant_id=TELEGRAM_TENANT_ID)
+    try:
+        await producer.enqueue(update)
+    except ValueError as e:
+        # process_payload puede levantar ValueError para updates sin texto
+        logger.info(f"[TelegramWebhook] Update descartado: {e}")
+
+    # --- 5. Responder 200 inmediatamente ---
+    return {"ok": True}

--- a/src/core/producers/telegram_producer.py
+++ b/src/core/producers/telegram_producer.py
@@ -1,0 +1,68 @@
+import logging
+import os
+from typing import Any
+
+from dotenv import load_dotenv
+
+from src.core.producers.base import BaseProducer
+from src.models.message import IncomingMessage
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+# Tenant por defecto para el canal Telegram.
+# Configurable en .env como TELEGRAM_CHANNEL_TENANT_ID.
+TELEGRAM_TENANT_ID = os.getenv("TELEGRAM_CHANNEL_TENANT_ID", "inasc_telegram")
+
+
+class TelegramProducer(BaseProducer):
+    """
+    Producer para el canal Telegram Webhook.
+
+    Recibe el payload JSON completo del update de Telegram y lo normaliza
+    hacia el formato estándar IncomingMessage para que el Agent Loop lo procese.
+
+    Diseño:
+    - El tenant_id se inyecta desde el entorno del servidor (nunca del payload).
+    - El platform_user_id es el chat_id de Telegram (str) para garantizar
+      que TelegramResponder pueda construir la respuesta de vuelta.
+    - Mensajes sin campo 'text' (fotos, stickers, etc.) levantan ValueError
+      para que el endpoint los ignore limpiamente.
+    """
+
+    def __init__(self, tenant_id: str = TELEGRAM_TENANT_ID):
+        self.tenant_id = tenant_id
+
+    async def process_payload(self, raw_payload: Any) -> IncomingMessage:
+        """
+        Mapea un update de Telegram al modelo IncomingMessage.
+
+        Estructura esperada del update:
+        {
+          "update_id": 123456,
+          "message": {
+            "chat": {"id": 789},
+            "from": {"username": "john_doe", "first_name": "John"},
+            "text": "Hola, ¿qué productos tienen?"
+          }
+        }
+        """
+        message = raw_payload.get("message", {})
+        text = message.get("text")
+
+        if not text:
+            raise ValueError("Update sin campo 'text' — ignorar (foto, sticker, etc.)")
+
+        chat_id = str(message["chat"]["id"])
+        from_data = message.get("from", {})
+        user_name = from_data.get("username") or from_data.get("first_name")
+
+        logger.info(f"[TelegramProducer] Mensaje de chat_id={chat_id}: '{text[:60]}'")
+
+        return IncomingMessage(
+            platform="telegram",
+            platform_user_id=chat_id,
+            tenant_id=self.tenant_id,
+            content=text,
+            user_name=user_name,
+        )

--- a/src/core/telegram_responder.py
+++ b/src/core/telegram_responder.py
@@ -1,0 +1,90 @@
+import logging
+import os
+from typing import Optional
+
+import httpx
+from dotenv import load_dotenv
+
+from src.core.telegram_utils import chunk_telegram_message, escape_html_for_telegram
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
+TELEGRAM_API_BASE = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}"
+
+
+class TelegramResponder:
+    """
+    Singleton responsable de enviar respuestas del agente al canal Telegram.
+
+    Es el equivalente simétrico de ConnectionManager.send_to_client() para WebSocket,
+    pero en lugar de poner en una cola asyncio, hace un HTTP POST a la API de Telegram.
+
+    Diseño:
+    - Usa httpx.AsyncClient con keep-alive para reutilizar conexiones TCP.
+    - Aplica chunking automático para respuestas > 4096 caracteres.
+    - Escapa HTML antes de enviar (parse_mode='HTML').
+    - Los errores de red se loguean sin re-lanzar para no romper el event loop.
+    """
+
+    def __init__(self):
+        self._client: Optional[httpx.AsyncClient] = None
+
+    @property
+    def client(self) -> httpx.AsyncClient:
+        """Lazy initialization del cliente HTTP (evita crear el client en import time)."""
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(timeout=10.0)
+        return self._client
+
+    async def send_message(self, chat_id: str, text: str) -> None:
+        """
+        Envía la respuesta del agente al chat_id de Telegram indicado.
+
+        Si la respuesta supera 4096 caracteres, se divide en múltiples mensajes.
+        Cada chunk se envía por separado manteniendo el orden.
+
+        Args:
+            chat_id: ID del chat de Telegram (como string, viene de platform_user_id).
+            text:    Texto de la respuesta generada por el LLM.
+        """
+        if not TELEGRAM_BOT_TOKEN:
+            logger.warning("[TelegramResponder] TELEGRAM_BOT_TOKEN no configurado. Respuesta no enviada.")
+            return
+
+        safe_text = escape_html_for_telegram(text)
+        chunks = chunk_telegram_message(safe_text)
+
+        for i, chunk in enumerate(chunks):
+            try:
+                response = await self.client.post(
+                    f"{TELEGRAM_API_BASE}/sendMessage",
+                    json={
+                        "chat_id": chat_id,
+                        "text": chunk,
+                        "parse_mode": "HTML",
+                    },
+                )
+                if response.status_code == 200:
+                    logger.info(
+                        f"[TelegramResponder] Chunk {i+1}/{len(chunks)} enviado a chat_id={chat_id}."
+                    )
+                else:
+                    logger.error(
+                        f"[TelegramResponder] Error {response.status_code} al enviar "
+                        f"chunk {i+1} a chat_id={chat_id}: {response.text[:200]}"
+                    )
+            except httpx.RequestError as e:
+                logger.error(
+                    f"[TelegramResponder] Error de red al enviar a chat_id={chat_id}: {e}"
+                )
+
+    async def close(self) -> None:
+        """Cierra el cliente HTTP. Llamar en el lifespan shutdown de FastAPI."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+
+
+# Instancia global Singleton
+telegram_responder = TelegramResponder()

--- a/src/core/telegram_utils.py
+++ b/src/core/telegram_utils.py
@@ -1,0 +1,79 @@
+"""
+Utilidades para el canal Telegram.
+Portado desde legacy/src/core/telegram_utils.py con adaptaciones menores de estilo.
+"""
+import re
+
+TELEGRAM_MAX_MESSAGE_LENGTH = 4096
+
+
+def escape_html_for_telegram(text: str) -> str:
+    """
+    Escapa caracteres HTML inválidos (<, >) para evitar errores 400 en Telegram
+    cuando se usa parse_mode='HTML', respetando las etiquetas válidas de Telegram.
+
+    Etiquetas permitidas por Telegram: b, strong, i, em, u, ins, s, strike, del, a, code, pre.
+    """
+    if not text:
+        return ""
+
+    allowed_tags = ["b", "strong", "i", "em", "u", "ins", "s", "strike", "del", "a", "code", "pre"]
+
+    # Expresión regular para coincidir con cualquier estructura que parezca etiqueta HTML
+    pattern = re.compile(r"(</?[a-zA-Z0-9]+[^>]*>)")
+
+    # split() con un grupo de captura devuelve las coincidencias intercaladas con el texto
+    # Ej: "hola <b>mundo</b>!" → ["hola ", "<b>", "mundo", "</b>", "!"]
+    parts = pattern.split(text)
+
+    for i in range(len(parts)):
+        if i % 2 == 1:
+            # Índices impares son posibles etiquetas
+            tag_name_match = re.match(r"</?([a-zA-Z0-9]+)", parts[i])
+            if tag_name_match and tag_name_match.group(1).lower() in allowed_tags:
+                continue  # Etiqueta permitida → dejar intacta
+            else:
+                parts[i] = parts[i].replace("<", "&lt;").replace(">", "&gt;")
+        else:
+            # Índices pares son texto normal fuera de etiquetas
+            parts[i] = parts[i].replace("<", "&lt;").replace(">", "&gt;")
+
+    return "".join(parts)
+
+
+def chunk_telegram_message(text: str, max_length: int = TELEGRAM_MAX_MESSAGE_LENGTH) -> list[str]:
+    """
+    Divide un mensaje largo en partes donde ninguna excede max_length.
+    Intenta dividir por saltos de línea para preservar el formato.
+    """
+    if not text:
+        return []
+
+    if len(text) <= max_length:
+        return [text]
+
+    chunks = []
+    current_text = text
+
+    while len(current_text) > max_length:
+        # Buscar el último salto de línea dentro del límite
+        split_index = current_text.rfind("\n", 0, max_length)
+
+        # Si no hay saltos, buscar el último espacio
+        if split_index == -1:
+            split_index = current_text.rfind(" ", 0, max_length)
+
+        # Si tampoco hay espacios, cortar exactamente en el límite
+        if split_index == -1:
+            split_index = max_length
+
+        chunk = current_text[:split_index].strip()
+        if chunk:
+            chunks.append(chunk)
+
+        current_text = current_text[split_index:].strip()
+
+    if current_text:
+        chunks.append(current_text)
+
+    return chunks

--- a/tests/functional/test_telegram_webhook.py
+++ b/tests/functional/test_telegram_webhook.py
@@ -1,0 +1,98 @@
+"""
+Tests funcionales para el endpoint POST /webhook/telegram.
+Verifican el protocolo HTTP del webhook sin llamar al LLM ni a Telegram.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+client = TestClient(app)
+
+VALID_UPDATE = {
+    "update_id": 888001,
+    "message": {
+        "chat": {"id": 111222},
+        "from": {"username": "prospecto_real"},
+        "text": "Buenos días, necesito información sobre espectrofotómetros.",
+    }
+}
+
+VALID_HEADERS = {"content-type": "application/json"}
+
+
+class TestTelegramWebhookEndpoint:
+
+    def test_webhook_retorna_200_inmediato(self):
+        """El endpoint responde 200 OK inmediatamente, sin esperar al LLM."""
+        with patch("src.api.routers.telegram.TelegramProducer") as MockProducer:
+            mock_instance = MockProducer.return_value
+            mock_instance.enqueue = AsyncMock()
+
+            response = client.post(
+                "/webhook/telegram",
+                json=VALID_UPDATE,
+                headers=VALID_HEADERS,
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+    def test_webhook_encola_mensaje(self):
+        """El endpoint encola el mensaje via TelegramProducer.enqueue()."""
+        with patch("src.api.routers.telegram.TelegramProducer") as MockProducer:
+            mock_instance = MockProducer.return_value
+            mock_instance.enqueue = AsyncMock()
+
+            client.post(
+                "/webhook/telegram",
+                json=VALID_UPDATE,
+                headers=VALID_HEADERS,
+            )
+
+            mock_instance.enqueue.assert_called_once_with(VALID_UPDATE)
+
+    def test_webhook_ignora_update_sin_mensaje_texto(self):
+        """Updates de fotos, stickers, etc. responden 200 sin encolar nada."""
+        update_foto = {
+            "update_id": 888002,
+            "message": {
+                "chat": {"id": 111222},
+                "from": {"username": "test"},
+                "photo": [{"file_id": "photo_abc"}],
+            }
+        }
+
+        with patch("src.api.routers.telegram.TelegramProducer") as MockProducer:
+            mock_instance = MockProducer.return_value
+            mock_instance.enqueue = AsyncMock()
+
+            response = client.post(
+                "/webhook/telegram",
+                json=update_foto,
+                headers=VALID_HEADERS,
+            )
+
+            assert response.status_code == 200
+            assert response.json() == {"ok": True}
+            mock_instance.enqueue.assert_not_called()
+
+    def test_webhook_rechaza_secret_token_invalido(self):
+        """Si TELEGRAM_WEBHOOK_SECRET está definido, un token inválido recibe 403."""
+        with patch.dict("os.environ", {"TELEGRAM_WEBHOOK_SECRET": "mi_secret_correcto"}):
+            # Recargamos el módulo para que lea la variable de entorno actualizada
+            import importlib
+            import src.api.routers.telegram as tg_module
+            importlib.reload(tg_module)
+
+            response = client.post(
+                "/webhook/telegram",
+                json=VALID_UPDATE,
+                headers={
+                    "content-type": "application/json",
+                    "X-Telegram-Bot-Api-Secret-Token": "token_incorrecto",
+                },
+            )
+
+        assert response.status_code == 403

--- a/tests/unit/test_telegram_producer.py
+++ b/tests/unit/test_telegram_producer.py
@@ -1,0 +1,86 @@
+"""
+Tests unitarios para TelegramProducer.
+Verifica que el payload del webhook de Telegram se normaliza correctamente
+hacia el modelo IncomingMessage sin llamar a dependencias externas.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from src.core.producers.telegram_producer import TelegramProducer
+
+
+VALID_UPDATE = {
+    "update_id": 999001,
+    "message": {
+        "chat": {"id": 456789},
+        "from": {"username": "test_user", "first_name": "Test"},
+        "text": "Hola, ¿qué balanzas tienen disponibles?",
+    }
+}
+
+
+class TestTelegramProducer:
+
+    @pytest.mark.asyncio
+    async def test_process_payload_mapea_campos_correctos(self):
+        """El payload de Telegram se mapea correctamente hacia IncomingMessage."""
+        producer = TelegramProducer(tenant_id="inasc_telegram")
+        msg = await producer.process_payload(VALID_UPDATE)
+
+        assert msg.platform == "telegram"
+        assert msg.platform_user_id == "456789"
+        assert msg.content == "Hola, ¿qué balanzas tienen disponibles?"
+        assert msg.user_name == "test_user"
+
+    @pytest.mark.asyncio
+    async def test_process_payload_tenant_id_inyectado_por_servidor(self):
+        """El tenant_id viene del entorno del servidor, nunca del payload de Telegram."""
+        producer = TelegramProducer(tenant_id="inasc_telegram")
+        # Añadimos un campo 'tenant_id' falso en el payload para verificar que se ignora
+        malicious_update = dict(VALID_UPDATE)
+        malicious_update["tenant_id"] = "tenant_hackeado"
+        msg = await producer.process_payload(malicious_update)
+
+        assert msg.tenant_id == "inasc_telegram"
+        assert msg.tenant_id != "tenant_hackeado"
+
+    @pytest.mark.asyncio
+    async def test_process_payload_update_sin_text_lanza_value_error(self):
+        """Un update sin 'text' (foto, sticker) debe levantar ValueError."""
+        producer = TelegramProducer(tenant_id="inasc_telegram")
+        update_sin_texto = {
+            "update_id": 999002,
+            "message": {
+                "chat": {"id": 456789},
+                "from": {"username": "test_user"},
+                # Sin campo 'text': es una foto o sticker
+                "photo": [{"file_id": "abc123"}],
+            }
+        }
+        with pytest.raises(ValueError):
+            await producer.process_payload(update_sin_texto)
+
+    @pytest.mark.asyncio
+    async def test_enqueue_llama_queue_manager(self):
+        """enqueue() debe normalizar el payload y llamar a queue_manager.enqueue_message()."""
+        producer = TelegramProducer(tenant_id="inasc_telegram")
+
+        with patch(
+            "src.core.producers.telegram_producer.TelegramProducer.process_payload",
+            new_callable=AsyncMock
+        ) as mock_process, patch(
+            "src.core.producers.base.queue_manager"
+        ) as mock_queue:
+            from src.models.message import IncomingMessage
+            mock_process.return_value = IncomingMessage(
+                platform="telegram",
+                platform_user_id="456789",
+                tenant_id="inasc_telegram",
+                content="Hola",
+            )
+            mock_queue.enqueue_message = AsyncMock()
+
+            await producer.enqueue(VALID_UPDATE)
+
+            mock_process.assert_called_once_with(VALID_UPDATE)
+            mock_queue.enqueue_message.assert_called_once()


### PR DESCRIPTION
## Resumen

Implementa el canal Telegram via Webhook (push), reemplazando el polling con  del agente legacy.

## Archivos nuevos

| Archivo | Descripción |
|---|---|
|  |  +  (portado del legacy) |
|  |  — normaliza el JSON del update →  |
|  |  singleton — llama  via The httpx command line client could not run because the required dependencies were not installed.
Make sure you've installed everything with: pip install 'httpx[cli]' |
|  |  — retorna 200 inmediato, valida secret token opcional |
|  | 4 tests unitarios |
|  | 4 tests funcionales |

## Archivos modificados

- : import + routing switch por  + cierre de The httpx command line client could not run because the required dependencies were not installed.
Make sure you've installed everything with: pip install 'httpx[cli]' en shutdown + registro del router
- : , 

## Tests



## Decisiones arquitectónicas

- **TelegramProducer** hereda  (mismo patrón que )
- **TelegramResponder** = equivalente de  para el canal HTTP
- El  se inyecta desde el entorno del servidor — nunca del payload de Telegram
- El  es opcional: permite desarrollo sin configuración extra

Closes #5