### PR TITLE
fix: unify tenant_id across all Producers (Issue #18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,20 +29,18 @@ DB_NAME=inasc_database
 TENANT_ID=inasc_001
 COMPANY_NAME="Instruments & Applied Science INASC S.A.S."
 COMPANY_URL="https://www.inasc.com.co"
-# Tenant que se asignará a los prospectos que lleguen por el canal WebSocket (Widget JS)
-WEB_CHANNEL_TENANT_ID=inasc_web
+
 
 
 # ==========================================
 # CANALES DE MENSAJERÍA
 # ==========================================
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
-# ID del tenant para el canal Telegram (configurable por entorno)
-TELEGRAM_CHANNEL_TENANT_ID=inasc_telegram
 # Token secreto para validar que los POSTs vienen de Telegram (opcional pero recomendado en produccion)
 # Generarlo con: python -c "import secrets; print(secrets.token_hex(32))"
 # TELEGRAM_WEBHOOK_SECRET=your_webhook_secret_here
 # WHATSAPP_API_TOKEN=your_whatsapp_token_here
+
 
 
 # ==========================================

--- a/src/api/routers/telegram.py
+++ b/src/api/routers/telegram.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 from fastapi import APIRouter, Header, HTTPException, Request
 
-from src.core.producers.telegram_producer import TelegramProducer, TELEGRAM_TENANT_ID
+from src.core.producers.telegram_producer import TelegramProducer, TENANT_ID as TELEGRAM_TENANT_ID
 
 logger = logging.getLogger(__name__)
 

--- a/src/core/producers/telegram_producer.py
+++ b/src/core/producers/telegram_producer.py
@@ -10,9 +10,10 @@ from src.models.message import IncomingMessage
 load_dotenv()
 logger = logging.getLogger(__name__)
 
-# Tenant por defecto para el canal Telegram.
-# Configurable en .env como TELEGRAM_CHANNEL_TENANT_ID.
-TELEGRAM_TENANT_ID = os.getenv("TELEGRAM_CHANNEL_TENANT_ID", "inasc_telegram")
+# tenant_id representa la EMPRESA (INASC S.A.S.), no el canal.
+# El canal queda en IncomingMessage.platform ('telegram', 'web', etc.)
+# Fix Issue #18: unificar tenant_id en todos los Producers.
+TENANT_ID = os.getenv("TENANT_ID", "inasc_001")
 
 
 class TelegramProducer(BaseProducer):
@@ -23,14 +24,15 @@ class TelegramProducer(BaseProducer):
     hacia el formato estándar IncomingMessage para que el Agent Loop lo procese.
 
     Diseño:
-    - El tenant_id se inyecta desde el entorno del servidor (nunca del payload).
-    - El platform_user_id es el chat_id de Telegram (str) para garantizar
-      que TelegramResponder pueda construir la respuesta de vuelta.
+    - El tenant_id se lee de TENANT_ID en .env (representa la empresa, no el canal).
+    - El canal queda en platform='telegram' del IncomingMessage.
+    - El platform_user_id es el chat_id de Telegram (str) para que
+      TelegramResponder pueda construir la respuesta de vuelta.
     - Mensajes sin campo 'text' (fotos, stickers, etc.) levantan ValueError
       para que el endpoint los ignore limpiamente.
     """
 
-    def __init__(self, tenant_id: str = TELEGRAM_TENANT_ID):
+    def __init__(self, tenant_id: str = TENANT_ID):
         self.tenant_id = tenant_id
 
     async def process_payload(self, raw_payload: Any) -> IncomingMessage:

--- a/src/core/producers/websocket_producer.py
+++ b/src/core/producers/websocket_producer.py
@@ -1,6 +1,15 @@
+import os
 from typing import Any
+from dotenv import load_dotenv
 from src.models.message import IncomingMessage
 from src.core.producers.base import BaseProducer
+
+load_dotenv()
+
+# tenant_id representa la EMPRESA (INASC S.A.S.), no el canal.
+# El canal ya queda en IncomingMessage.platform ('web', 'telegram', etc.)
+# Fix Issue #18: unificar tenant_id en todos los Producers.
+TENANT_ID = os.getenv("TENANT_ID", "inasc_001")
 
 
 class WebSocketProducer(BaseProducer):
@@ -21,6 +30,9 @@ class WebSocketProducer(BaseProducer):
         "user_name": "Juan Pérez"     # Opcional
     }
     """
+
+    def __init__(self, tenant_id: str = TENANT_ID):
+        self.tenant_id = tenant_id
 
     async def process_payload(self, raw_payload: Any) -> IncomingMessage:
         return IncomingMessage(


### PR DESCRIPTION
## Bug Fix — Issue #18

### Problema
 y  inyectaban  distintos ( / ) para la misma empresa, creando usuarios y conversaciones duplicadas en BD cross-canal.

### Fix
Ambos Producers ahora leen  del  (), que representa la empresa. El canal queda en .

### Archivos
- :  → 
- :  → 
- : import alias actualizado
- : variables deprecadas eliminadas

### Tests: 8/8 PASSED

Closes #18