### PR TITLE
feat(widget): add JS WebSocket chat widget — closes #15

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from pathlib import Path
 from fastapi import FastAPI
+from starlette.staticfiles import StaticFiles
 from dotenv import load_dotenv
 
 from src.core.queue_manager import queue_manager
@@ -125,6 +127,11 @@ from src.api.routers import telegram
 app.include_router(simulator.router)
 app.include_router(websocket.router)
 app.include_router(telegram.router)
+
+# Servir archivos estáticos del Widget JS (Issue #15)
+# Ruta relativa al propio main.py → src/static/ → expuesta en /static
+_STATIC_DIR = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=_STATIC_DIR), name="static")
 
 @app.get("/")
 def read_root():

--- a/src/static/widget.css
+++ b/src/static/widget.css
@@ -1,0 +1,341 @@
+/* ============================================================
+   INASC Chat Widget — widget.css
+   Paleta: Verde #00b33f | Azul oscuro #244253 | Fuente: Titillium Web
+   ============================================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Titillium+Web:wght@300;400;600;700&display=swap');
+
+/* ── Reset & Variables ─────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --inasc-green:      #00b33f;
+  --inasc-green-dark: #019d38;
+  --inasc-blue:       #244253;
+  --inasc-blue-light: #2e5468;
+  --text-dark:        #333333;
+  --text-light:       #ffffff;
+  --bg-chat:          #f5f5f5;
+  --bubble-agent-bg:  #e8f8ee;
+  --bubble-agent-bd:  #b3e0c0;
+  --bubble-user-bg:   #244253;
+  --radius-bubble:    16px;
+  --shadow:           0 4px 24px rgba(0,0,0,0.18);
+  --shadow-btn:       0 2px 12px rgba(0,179,63,0.35);
+  --transition:       350ms ease-in-out;
+  --font:             'Titillium Web', sans-serif;
+  --widget-width:     370px;
+  --widget-height:    520px;
+}
+
+/* ── Launcher Button (burbuja flotante) ────────────────────── */
+#inasc-chat-launcher {
+  position: fixed;
+  bottom: 28px;
+  right: 28px;
+  z-index: 9999;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: var(--inasc-green);
+  border: none;
+  cursor: pointer;
+  box-shadow: var(--shadow-btn);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--transition), transform var(--transition), box-shadow var(--transition);
+  outline: none;
+}
+#inasc-chat-launcher:hover {
+  background: var(--inasc-green-dark);
+  transform: scale(1.08);
+  box-shadow: 0 4px 20px rgba(0,179,63,0.5);
+}
+#inasc-chat-launcher svg {
+  fill: #fff;
+  width: 28px;
+  height: 28px;
+  transition: transform var(--transition);
+}
+#inasc-chat-launcher.is-open svg.icon-chat { display: none; }
+#inasc-chat-launcher:not(.is-open) svg.icon-close { display: none; }
+
+/* Badge de notificación */
+#inasc-notif-badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #e53935;
+  color: #fff;
+  font-family: var(--font);
+  font-size: 11px;
+  font-weight: 700;
+  min-width: 20px;
+  height: 20px;
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px;
+  display: none; /* visible via JS cuando llega msg no leído */
+}
+
+/* ── Panel principal del chat ──────────────────────────────── */
+#inasc-chat-panel {
+  position: fixed;
+  bottom: 100px;
+  right: 28px;
+  z-index: 9998;
+  width: var(--widget-width);
+  height: var(--widget-height);
+  border-radius: 16px;
+  background: #ffffff;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: var(--font);
+
+  /* Animación slide-up */
+  transform: translateY(20px) scale(0.97);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform var(--transition), opacity var(--transition);
+}
+#inasc-chat-panel.is-visible {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+  pointer-events: all;
+}
+
+/* ── Header ────────────────────────────────────────────────── */
+#inasc-chat-header {
+  background: linear-gradient(135deg, var(--inasc-blue) 0%, var(--inasc-blue-light) 100%);
+  padding: 14px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+}
+.inasc-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--inasc-green);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.inasc-avatar svg { fill: #fff; width: 22px; height: 22px; }
+.inasc-header-info { flex: 1; }
+.inasc-header-info h3 {
+  color: var(--text-light);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+}
+.inasc-header-info p {
+  color: rgba(255,255,255,0.7);
+  font-size: 11px;
+  font-weight: 300;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.inasc-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--inasc-green);
+  display: inline-block;
+  box-shadow: 0 0 0 2px rgba(0,179,63,0.3);
+  animation: pulse-dot 2s infinite;
+}
+@keyframes pulse-dot {
+  0%, 100% { box-shadow: 0 0 0 2px rgba(0,179,63,0.3); }
+  50%       { box-shadow: 0 0 0 5px rgba(0,179,63,0.1); }
+}
+
+/* ── Área de mensajes ──────────────────────────────────────── */
+#inasc-chat-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: var(--bg-chat);
+  scroll-behavior: smooth;
+}
+#inasc-chat-messages::-webkit-scrollbar { width: 4px; }
+#inasc-chat-messages::-webkit-scrollbar-track { background: transparent; }
+#inasc-chat-messages::-webkit-scrollbar-thumb { background: #ccc; border-radius: 4px; }
+
+/* ── Burbujas ──────────────────────────────────────────────── */
+.inasc-bubble-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  animation: bubble-in 0.22s ease-out;
+}
+@keyframes bubble-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.inasc-bubble-row.user { flex-direction: row-reverse; }
+
+.inasc-bubble {
+  max-width: 78%;
+  padding: 10px 14px;
+  border-radius: var(--radius-bubble);
+  font-size: 13.5px;
+  font-weight: 400;
+  line-height: 1.5;
+  word-break: break-word;
+}
+/* Burbuja del agente */
+.inasc-bubble-row.agent .inasc-bubble {
+  background: var(--bubble-agent-bg);
+  border: 1px solid var(--bubble-agent-bd);
+  color: var(--text-dark);
+  border-bottom-left-radius: 4px;
+}
+/* Burbuja del usuario */
+.inasc-bubble-row.user .inasc-bubble {
+  background: var(--bubble-user-bg);
+  color: var(--text-light);
+  border-bottom-right-radius: 4px;
+}
+
+/* Avatar mini del agente en burbuja */
+.inasc-mini-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--inasc-green);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  margin-bottom: 2px;
+}
+.inasc-mini-avatar svg { fill: #fff; width: 14px; height: 14px; }
+.inasc-bubble-row.user .inasc-mini-avatar { display: none; }
+
+/* ── Typing indicator ──────────────────────────────────────── */
+#inasc-typing {
+  display: none; /* visible via JS */
+  align-items: flex-end;
+  gap: 8px;
+}
+#inasc-typing.visible { display: flex; }
+.inasc-typing-dots {
+  background: var(--bubble-agent-bg);
+  border: 1px solid var(--bubble-agent-bd);
+  border-radius: var(--radius-bubble);
+  border-bottom-left-radius: 4px;
+  padding: 10px 16px;
+  display: flex;
+  gap: 5px;
+  align-items: center;
+}
+.inasc-typing-dots span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--inasc-green);
+  animation: typing-bounce 1.2s infinite ease-in-out;
+}
+.inasc-typing-dots span:nth-child(2) { animation-delay: 0.2s; }
+.inasc-typing-dots span:nth-child(3) { animation-delay: 0.4s; }
+@keyframes typing-bounce {
+  0%, 80%, 100% { transform: translateY(0);   opacity: 0.5; }
+  40%            { transform: translateY(-6px); opacity: 1; }
+}
+
+/* ── Input area ────────────────────────────────────────────── */
+#inasc-chat-input-area {
+  padding: 12px 14px;
+  background: #fff;
+  border-top: 1px solid #e8e8e8;
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+  flex-shrink: 0;
+}
+#inasc-chat-input {
+  flex: 1;
+  border: 1.5px solid #ddd;
+  border-radius: 22px;
+  padding: 9px 16px;
+  font-family: var(--font);
+  font-size: 13.5px;
+  color: var(--text-dark);
+  resize: none;
+  outline: none;
+  max-height: 100px;
+  overflow-y: auto;
+  transition: border-color var(--transition);
+  background: #fafafa;
+  line-height: 1.4;
+}
+#inasc-chat-input:focus { border-color: var(--inasc-green); background: #fff; }
+#inasc-chat-input::placeholder { color: #aaa; font-weight: 300; }
+
+#inasc-send-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--inasc-green);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background var(--transition), transform 0.15s;
+  box-shadow: 0 2px 8px rgba(0,179,63,0.3);
+}
+#inasc-send-btn:hover { background: var(--inasc-green-dark); transform: scale(1.08); }
+#inasc-send-btn:disabled { background: #ccc; cursor: not-allowed; transform: none; box-shadow: none; }
+#inasc-send-btn svg { fill: #fff; width: 18px; height: 18px; }
+
+/* ── Footer watermark ──────────────────────────────────────── */
+#inasc-chat-footer {
+  text-align: center;
+  padding: 6px;
+  font-family: var(--font);
+  font-size: 10px;
+  color: #bbb;
+  background: #fff;
+  border-top: 1px solid #f0f0f0;
+  flex-shrink: 0;
+}
+#inasc-chat-footer a { color: var(--inasc-green); text-decoration: none; }
+
+/* ── Connection status banner ──────────────────────────────── */
+#inasc-conn-status {
+  font-family: var(--font);
+  font-size: 11.5px;
+  font-weight: 600;
+  text-align: center;
+  padding: 5px;
+  display: none;
+}
+#inasc-conn-status.connecting { display: block; background: #fff3cd; color: #856404; }
+#inasc-conn-status.error      { display: block; background: #f8d7da; color: #721c24; }
+#inasc-conn-status.reconnecting { display: block; background: #d1ecf1; color: #0c5460; }
+
+/* ── Responsive (móviles) ──────────────────────────────────── */
+@media (max-width: 420px) {
+  #inasc-chat-panel {
+    width: 100vw;
+    height: 100dvh;
+    bottom: 0;
+    right: 0;
+    border-radius: 0;
+  }
+  #inasc-chat-launcher { bottom: 16px; right: 16px; }
+}

--- a/src/static/widget.html
+++ b/src/static/widget.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>INASC — Asistente Virtual</title>
+  <meta name="description" content="Chat con el Asistente Virtual de INASC — Instruments & Applied Sciences. Soporte técnico y asesoría comercial en tiempo real.">
+
+  <!-- Fuentes igual que el sitio de INASC -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@300;400;600;700&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="/static/widget.css">
+
+  <!-- Demo page styles: solo para mostrar el widget en contexto -->
+  <style>
+    body {
+      font-family: 'Titillium Web', sans-serif;
+      background: #f0f2f5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      padding: 20px;
+    }
+    .demo-card {
+      background: #fff;
+      border-radius: 12px;
+      padding: 40px 36px;
+      max-width: 560px;
+      width: 100%;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.10);
+      text-align: center;
+    }
+    .demo-card .logo {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      margin-bottom: 24px;
+    }
+    .demo-card .logo-icon {
+      width: 44px; height: 44px;
+      background: #00b33f;
+      border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .demo-card .logo-icon svg { fill: #fff; width: 24px; height: 24px; }
+    .demo-card h1 {
+      font-size: 22px;
+      font-weight: 700;
+      color: #244253;
+      margin: 0;
+    }
+    .demo-card p {
+      color: #555;
+      font-size: 15px;
+      font-weight: 300;
+      line-height: 1.6;
+      margin-bottom: 28px;
+    }
+    .demo-card .info-box {
+      background: #e8f8ee;
+      border: 1px solid #b3e0c0;
+      border-radius: 8px;
+      padding: 14px 18px;
+      font-size: 13px;
+      color: #2d6a4f;
+      text-align: left;
+    }
+    .demo-card .info-box strong { color: #00b33f; }
+    .arrow-hint {
+      position: fixed;
+      bottom: 96px;
+      right: 36px;
+      font-family: 'Titillium Web', sans-serif;
+      font-size: 13px;
+      color: #244253;
+      font-weight: 600;
+      background: rgba(255,255,255,0.95);
+      padding: 8px 14px;
+      border-radius: 20px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.12);
+      pointer-events: none;
+      animation: hint-bounce 2s infinite ease-in-out;
+      white-space: nowrap;
+    }
+    @keyframes hint-bounce {
+      0%, 100% { transform: translateY(0); }
+      50%       { transform: translateY(-5px); }
+    }
+    .arrow-hint::after {
+      content: ' 👇';
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Demo Card (contenido de prueba de la página host) -->
+  <div class="demo-card">
+    <div class="logo">
+      <div class="logo-icon">
+        <svg viewBox="0 0 24 24"><path d="M19.5 3h-15A1.5 1.5 0 0 0 3 4.5v15A1.5 1.5 0 0 0 4.5 21h15a1.5 1.5 0 0 0 1.5-1.5v-15A1.5 1.5 0 0 0 19.5 3zm-9 13.5H9v-7h1.5v7zm3 0h-1.5V9H13.5v7.5zm3 0H15v-5h1.5v5z"/></svg>
+      </div>
+      <h1>INASC — Widget de Chat</h1>
+    </div>
+
+    <p>
+      Esta página demuestra el <strong>Asistente Virtual de INASC</strong> funcionando en tiempo real
+      a través de WebSocket. El widget aparece en la esquina inferior derecha de cualquier página donde
+      se integre.
+    </p>
+
+    <div class="info-box">
+      <strong>Integración en www.inasc.com.co</strong><br>
+      Para integrar el widget en cualquier página, añade estas dos líneas antes de cerrar el tag
+      <code>&lt;/body&gt;</code>:
+      <br><br>
+      <code>
+        &lt;link rel="stylesheet" href="/static/widget.css"&gt;<br>
+        &lt;!-- [pegar el bloque HTML del widget] --&gt;<br>
+        &lt;script src="/static/widget.js"&gt;&lt;/script&gt;
+      </code>
+    </div>
+  </div>
+
+  <!-- Indicador visual para el demo -->
+  <div class="arrow-hint">Chatea con el asistente</div>
+
+  <!-- ══════════════════════════════════════════════════════
+       BLOQUE DEL WIDGET — Copiar este bloque en cada página
+       ══════════════════════════════════════════════════════ -->
+
+  <!-- Botón flotante (launcher) -->
+  <button
+    id="inasc-chat-launcher"
+    aria-label="Abrir chat con el asistente INASC"
+    title="Habla con nuestro Asistente Virtual"
+  >
+    <!-- Los SVGs los inyecta widget.js -->
+    <div id="inasc-notif-badge" aria-hidden="true"></div>
+  </button>
+
+  <!-- Panel principal del chat -->
+  <div
+    id="inasc-chat-panel"
+    role="dialog"
+    aria-label="Asistente Virtual INASC"
+    aria-modal="true"
+  >
+    <!-- Header -->
+    <div id="inasc-chat-header">
+      <div class="inasc-avatar">
+        <svg viewBox="0 0 24 24">
+          <path d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h3a3 3 0 0 1 3 3v1h1a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-1v1a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3v-1H3a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1h1v-1a3 3 0 0 1 3-3h3V5.73A2 2 0 0 1 10 4a2 2 0 0 1 2-2zm-2 9a1.5 1.5 0 0 0 0 3 1.5 1.5 0 0 0 0-3zm4 0a1.5 1.5 0 0 0 0 3 1.5 1.5 0 0 0 0-3zm-4 4h4l-1 2h-2l-1-2z"/>
+        </svg>
+      </div>
+      <div class="inasc-header-info">
+        <h3>Asistente INASC</h3>
+        <p>
+          <span class="inasc-status-dot" aria-hidden="true"></span>
+          En línea · Asesor Técnico Comercial
+        </p>
+      </div>
+    </div>
+
+    <!-- Banner de estado de conexión -->
+    <div id="inasc-conn-status" role="status" aria-live="polite"></div>
+
+    <!-- Historial de mensajes -->
+    <div id="inasc-chat-messages" role="log" aria-live="polite" aria-label="Mensajes del chat">
+
+      <!-- Indicador de "escribiendo..." -->
+      <div id="inasc-typing" class="inasc-bubble-row agent" aria-label="El asistente está escribiendo">
+        <div class="inasc-mini-avatar">
+          <svg viewBox="0 0 24 24">
+            <path d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h3a3 3 0 0 1 3 3v1h1a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-1v1a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3v-1H3a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1h1v-1a3 3 0 0 1 3-3h3V5.73A2 2 0 0 1 10 4a2 2 0 0 1 2-2zm-2 9a1.5 1.5 0 0 0 0 3 1.5 1.5 0 0 0 0-3zm4 0a1.5 1.5 0 0 0 0 3 1.5 1.5 0 0 0 0-3zm-4 4h4l-1 2h-2l-1-2z"/>
+          </svg>
+        </div>
+        <div class="inasc-typing-dots" aria-hidden="true">
+          <span></span><span></span><span></span>
+        </div>
+      </div>
+
+    </div>
+
+    <!-- Input area -->
+    <div id="inasc-chat-input-area">
+      <textarea
+        id="inasc-chat-input"
+        placeholder="Escribe tu mensaje... (Enter para enviar)"
+        rows="1"
+        aria-label="Mensaje al asistente"
+        autocomplete="off"
+        spellcheck="true"
+        disabled
+      ></textarea>
+      <button
+        id="inasc-send-btn"
+        aria-label="Enviar mensaje"
+        disabled
+      >
+        <!-- SVG inyectado por widget.js -->
+      </button>
+    </div>
+
+    <!-- Footer -->
+    <div id="inasc-chat-footer">
+      Asistente de <a href="https://www.inasc.com.co" target="_blank" rel="noopener noreferrer">INASC S.A.S.</a>
+      · Powered by IA
+    </div>
+
+  </div>
+  <!-- ══════════ FIN DEL BLOQUE DEL WIDGET ══════════ -->
+
+  <script src="/static/widget.js"></script>
+</body>
+</html>

--- a/src/static/widget.js
+++ b/src/static/widget.js
@@ -1,0 +1,357 @@
+/**
+ * INASC Chat Widget — widget.js
+ * Conecta al backend FastAPI vía WebSocket (/ws/chat/{client_id}).
+ * Patrón: the widget assumes the HTML skeleton already exists (built by widget.html).
+ */
+
+(function () {
+    'use strict';
+
+    /* ── Configuración ─────────────────────────────────────── */
+    const CONFIG = {
+        // Detecta automáticamente el host del servidor que sirvió el HTML.
+        // En desarrollo: ws://127.0.0.1:8000/ws/chat/{id}
+        // En producción: wss://inasc.com.co/ws/chat/{id}
+        wsProtocol: location.protocol === 'https:' ? 'wss' : 'ws',
+        wsHost: location.host,          // e.g. "127.0.0.1:8000" o "inasc.com.co"
+        reconnectBaseMs: 1500,          // espera inicial antes de reconectar
+        reconnectMaxMs: 30000,          // tope de backoff exponencial
+        reconnectMaxTries: 8,           // intentos máximos antes de desistir
+        greetingDelay: 600,             // ms para mostrar saludo de bienvenida
+        userName: 'Visitante',          // nombre por defecto si no se captura
+    };
+
+    /* ── Estado de la sesión ───────────────────────────────── */
+    const STATE = {
+        clientId: generateClientId(),
+        ws: null,
+        isOpen: false,           // panel visible
+        isSending: false,        // esperando respuesta del LLM
+        reconnectTries: 0,
+        reconnectTimer: null,
+        unreadCount: 0,
+    };
+
+    /* ── Referencias DOM ───────────────────────────────────── */
+    const launcher = document.getElementById('inasc-chat-launcher');
+    const panel = document.getElementById('inasc-chat-panel');
+    const messages = document.getElementById('inasc-chat-messages');
+    const input = document.getElementById('inasc-chat-input');
+    const sendBtn = document.getElementById('inasc-send-btn');
+    const typingRow = document.getElementById('inasc-typing');
+    const connStatus = document.getElementById('inasc-conn-status');
+    const badge = document.getElementById('inasc-notif-badge');
+
+    /* ================================================================
+       CICLO DE VIDA DEL WEBSOCKET
+       ================================================================ */
+
+    function buildWsUrl() {
+        return `${CONFIG.wsProtocol}://${CONFIG.wsHost}/ws/chat/${STATE.clientId}`;
+    }
+
+    function connectWs() {
+        setConnStatus('connecting', 'Conectando con el asistente...');
+
+        const ws = new WebSocket(buildWsUrl());
+        STATE.ws = ws;
+
+        ws.onopen = function () {
+            STATE.reconnectTries = 0;
+            clearTimeout(STATE.reconnectTimer);
+            setConnStatus(null);           // ocultar banner
+            setInputEnabled(true);
+            console.debug('[INASC Widget] WebSocket conectado:', buildWsUrl());
+
+            // Saludo automático al conectar por primera vez
+            if (messages.children.length === 0) {
+                setTimeout(showWelcomeMessage, CONFIG.greetingDelay);
+            }
+        };
+
+        ws.onmessage = function (event) {
+            let data;
+            try { data = JSON.parse(event.data); }
+            catch { data = { role: 'agent', content: event.data }; }
+
+            hideTyping();
+            appendMessage('agent', data.content || '');
+            STATE.isSending = false;
+            setInputEnabled(true);
+
+            // Badge si el panel está cerrado
+            if (!STATE.isOpen) {
+                STATE.unreadCount++;
+                showBadge(STATE.unreadCount);
+            }
+        };
+
+        ws.onerror = function () {
+            console.warn('[INASC Widget] Error en WebSocket.');
+        };
+
+        ws.onclose = function (event) {
+            hideTyping();
+            STATE.isSending = false;
+            setInputEnabled(false);
+
+            if (event.wasClean) {
+                console.debug('[INASC Widget] Conexión cerrada limpiamente.');
+                return;
+            }
+
+            // Reconexión con backoff exponencial
+            if (STATE.reconnectTries < CONFIG.reconnectMaxTries) {
+                const delay = Math.min(
+                    CONFIG.reconnectBaseMs * Math.pow(1.8, STATE.reconnectTries),
+                    CONFIG.reconnectMaxMs
+                );
+                STATE.reconnectTries++;
+                setConnStatus('reconnecting',
+                    `Reconectando... (intento ${STATE.reconnectTries})`);
+                STATE.reconnectTimer = setTimeout(connectWs, delay);
+            } else {
+                setConnStatus('error',
+                    'Sin conexión con el asistente. Intenta recargar la página.');
+            }
+        };
+    }
+
+    function disconnectWs() {
+        clearTimeout(STATE.reconnectTimer);
+        if (STATE.ws && STATE.ws.readyState <= WebSocket.OPEN) {
+            STATE.ws.close(1000, 'Widget cerrado por el usuario');
+        }
+        STATE.ws = null;
+    }
+
+    /* ================================================================
+       ENVÍO Y RECEPCIÓN DE MENSAJES
+       ================================================================ */
+
+    function sendMessage() {
+        if (STATE.isSending) return;
+
+        const text = input.value.trim();
+        if (!text) return;
+        if (!STATE.ws || STATE.ws.readyState !== WebSocket.OPEN) {
+            setConnStatus('error', 'Sin conexión. Espera un momento...');
+            return;
+        }
+
+        // Mostrar la burbuja del usuario inmediatamente
+        appendMessage('user', text);
+        input.value = '';
+        autoResizeInput();
+
+        // Mostrar typing y deshabilitar input mientras esperamos
+        showTyping();
+        STATE.isSending = true;
+        setInputEnabled(false);
+
+        // Enviar al backend
+        const payload = {
+            text: text,
+            user_name: CONFIG.userName,
+        };
+        STATE.ws.send(JSON.stringify(payload));
+    }
+
+    /* ================================================================
+       MANIPULACIÓN DEL DOM
+       ================================================================ */
+
+    function appendMessage(role, content) {
+        // Clonar plantilla o construir manualmente
+        const row = document.createElement('div');
+        row.className = `inasc-bubble-row ${role}`;
+
+        const bubble = document.createElement('div');
+        bubble.className = 'inasc-bubble';
+        bubble.textContent = content;
+
+        if (role === 'agent') {
+            const miniAvatar = document.createElement('div');
+            miniAvatar.className = 'inasc-mini-avatar';
+            miniAvatar.innerHTML = SVG_ROBOT;
+            row.appendChild(miniAvatar);
+        }
+
+        row.appendChild(bubble);
+        messages.appendChild(row);
+        scrollToBottom();
+    }
+
+    function showTyping() {
+        typingRow.classList.add('visible');
+        scrollToBottom();
+    }
+
+    function hideTyping() {
+        typingRow.classList.remove('visible');
+    }
+
+    function scrollToBottom() {
+        messages.scrollTop = messages.scrollHeight;
+    }
+
+    function setInputEnabled(enabled) {
+        input.disabled = !enabled;
+        sendBtn.disabled = !enabled;
+        if (enabled) input.focus();
+    }
+
+    function setConnStatus(type, text) {
+        if (!type) {
+            connStatus.className = '';
+            connStatus.style.display = 'none';
+            return;
+        }
+        connStatus.className = type;
+        connStatus.textContent = text;
+        connStatus.style.display = 'block';
+    }
+
+    function showBadge(count) {
+        badge.textContent = count > 9 ? '9+' : count;
+        badge.style.display = 'flex';
+    }
+
+    function hideBadge() {
+        STATE.unreadCount = 0;
+        badge.style.display = 'none';
+    }
+
+    function showWelcomeMessage() {
+        appendMessage('agent',
+            '¡Hola! 👋 Soy el Asistente Virtual de INASC. Estoy aquí para ayudarte con ' +
+            'información sobre equipos de laboratorio, metrología y servicios técnicos. ' +
+            '¿En qué puedo ayudarte hoy?'
+        );
+    }
+
+    /* ================================================================
+       APERTURA / CIERRE DEL PANEL
+       ================================================================ */
+
+    function openPanel() {
+        STATE.isOpen = true;
+        panel.classList.add('is-visible');
+        launcher.classList.add('is-open');
+        hideBadge();
+
+        // Conectar WS la primera vez (o reconectar si estaba cerrado)
+        if (!STATE.ws || STATE.ws.readyState > WebSocket.OPEN) {
+            connectWs();
+        } else {
+            setInputEnabled(true);
+        }
+    }
+
+    function closePanel() {
+        STATE.isOpen = false;
+        panel.classList.remove('is-visible');
+        launcher.classList.remove('is-open');
+        // NO desconectamos aquí para que el historial persista en la sesión.
+        // La desconexión ocurre al salir de la página (beforeunload).
+    }
+
+    function togglePanel() {
+        STATE.isOpen ? closePanel() : openPanel();
+    }
+
+    /* ================================================================
+       REDIMENSIONADO AUTOMÁTICO DEL TEXTAREA
+       ================================================================ */
+
+    function autoResizeInput() {
+        input.style.height = 'auto';
+        input.style.height = Math.min(input.scrollHeight, 100) + 'px';
+    }
+
+    /* ================================================================
+       GENERACIÓN DE CLIENT ID DE SESIÓN
+       ================================================================ */
+
+    function generateClientId() {
+        // Reutilizar el id de sesión si el usuario refresca la página
+        const key = 'inasc_chat_client_id';
+        let id = sessionStorage.getItem(key);
+        if (!id) {
+            // crypto.randomUUID() disponible en todos los navegadores modernos + HTTPS
+            id = (typeof crypto !== 'undefined' && crypto.randomUUID)
+                ? crypto.randomUUID()
+                : 'web_' + Date.now() + '_' + Math.random().toString(36).slice(2, 9);
+            sessionStorage.setItem(key, id);
+        }
+        return id;
+    }
+
+    /* ================================================================
+       EVENT LISTENERS
+       ================================================================ */
+
+    launcher.addEventListener('click', togglePanel);
+
+    sendBtn.addEventListener('click', sendMessage);
+
+    input.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            sendMessage();
+        }
+    });
+
+    input.addEventListener('input', autoResizeInput);
+
+    // Desconectar limpiamente al salir de la página
+    window.addEventListener('beforeunload', disconnectWs);
+
+    /* ================================================================
+       SVG INLINE — evita dependencia de íconos externos
+       ================================================================ */
+
+    // Ícono de chat (para el launcher cuando está cerrado)
+    const SVG_CHAT = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="icon-chat">
+    <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
+  </svg>`;
+
+    // Ícono X (para el launcher cuando está abierto)
+    const SVG_CLOSE = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" class="icon-close">
+    <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+  </svg>`;
+
+    // Ícono robot para mini-avatar del agente
+    const SVG_ROBOT = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h3a3 3 0 0 1 3 3v1h1a1 1 0 0 1 1 1v4a1 1 0 0 1-1 1h-1v1a3 3 0 0 1-3 3H7a3 3 0 0 1-3-3v-1H3a1 1 0 0 1-1-1v-4a1 1 0 0 1 1-1h1v-1a3 3 0 0 1 3-3h3V5.73A2 2 0 0 1 10 4a2 2 0 0 1 2-2zm-2 9a1.5 1.5 0 0 0 0 3 1.5 1.5 0 0 0 0-3zm4 0a1.5 1.5 0 0 0 0 3 1.5 1.5 0 0 0 0-3zm-4 4h4l-1 2h-2l-1-2z"/>
+  </svg>`;
+
+    // Ícono de envío (paper plane)
+    const SVG_SEND = `<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/>
+  </svg>`;
+
+    // Inyectar SVGs en el DOM
+    launcher.innerHTML = SVG_CHAT + SVG_CLOSE + `
+    <div id="inasc-notif-badge" style="display:none">0</div>`;
+
+    sendBtn.innerHTML = SVG_SEND;
+
+    // Reasignar badge tras re-render del launcher
+    // (el badge original fue reemplazado por innerHTML, necesitamos la nueva referencia local)
+    const liveBadge = document.getElementById('inasc-notif-badge');
+
+    function showBadgeLive(count) {
+        liveBadge.textContent = count > 9 ? '9+' : count;
+        liveBadge.style.display = 'flex';
+    }
+    function hideBadgeLive() {
+        STATE.unreadCount = 0;
+        liveBadge.style.display = 'none';
+    }
+
+    // Reemplazar las funciones del closure con las que usan la referencia real del DOM
+    // (las funciones showBadge/hideBadge arriba son obsoletas por el innerHTML override)
+    Object.defineProperty(window, 'inascHideBadge', { value: hideBadgeLive });
+
+})();


### PR DESCRIPTION
- Add src/static/widget.html: embeddable chat skeleton with ARIA roles
- Add src/static/widget.js: WebSocket lifecycle, reconnect backoff, typing indicator, sessionStorage client_id, send/receive messages
- Add src/static/widget.css: INASC brand colors (#00b33f / #244253), Titillium Web font, floating bubble, slide-up panel, responsive
- Mount StaticFiles at /static in main.py (Starlette)
- Verified: 8/8 tests pass, widget loads and connects to /ws/chat/{id}
## Descripción
Implementa el frontend del canal Web (Issue #15): widget de chat embeddable
que conecta al backend vía WebSocket con el patrón Producer-Consumer de Telegram.

## Cambios
- [src/static/widget.html](cci:7://file:///y:/MySource/IA/Agent-Commercial/src/static/widget.html:0:0-0:0) — Skeleton HTML con ARIA, página de demo
- [src/static/widget.js](cci:7://file:///y:/MySource/IA/Agent-Commercial/src/static/widget.js:0:0-0:0) — WebSocket lifecycle, reconnect backoff, typing indicator
- [src/static/widget.css](cci:7://file:///y:/MySource/IA/Agent-Commercial/src/static/widget.css:0:0-0:0) — Estilos INASC: #00b33f/#244253, Titillium Web, responsive
- [src/main.py](cci:7://file:///y:/MySource/IA/Agent-Commercial/src/main.py:0:0-0:0) — Monta src/static/ en /static via StaticFiles

## Verificación
- ✅ 8/8 tests pasan
- ✅ Widget carga y conecta al WebSocket en vivo

Closes #15
