### PR TITLE
feat(whatsapp): WhatsApp Cloud API Webhook — closes #16

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,7 +39,16 @@ TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 # Token secreto para validar que los POSTs vienen de Telegram (opcional pero recomendado en produccion)
 # Generarlo con: python -c "import secrets; print(secrets.token_hex(32))"
 # TELEGRAM_WEBHOOK_SECRET=your_webhook_secret_here
-# WHATSAPP_API_TOKEN=your_whatsapp_token_here
+
+# ── WhatsApp Cloud API (Meta) ──────────────────────────────────────
+# Obtener en: developers.facebook.com → Tu App → WhatsApp → Getting Started
+# WHATSAPP_API_TOKEN: Token Bearer de acceso (temporal 24h o permanente con System User)
+WHATSAPP_API_TOKEN=your_whatsapp_api_token_here
+# WHATSAPP_PHONE_NUMBER_ID: ID del número de teléfono de envío (no es el número en sí)
+WHATSAPP_PHONE_NUMBER_ID=your_phone_number_id_here
+# WHATSAPP_VERIFY_TOKEN: String libre que defines tú y configuras en el Meta Developer Dashboard
+# al registrar el webhook. Debe coincidir exactamente en GET /webhook/whatsapp
+WHATSAPP_VERIFY_TOKEN=inasc_whatsapp_verify_token
 
 
 

--- a/src/api/routers/whatsapp.py
+++ b/src/api/routers/whatsapp.py
@@ -1,0 +1,105 @@
+import logging
+import os
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from src.core.producers.whatsapp_producer import WhatsAppProducer, TENANT_ID as WA_TENANT_ID
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["WhatsApp"])
+
+# Token de verificación que Meta usa para validar el webhook.
+# Debe coincidir con el valor configurado en el Meta Developer Dashboard.
+# Definir WHATSAPP_VERIFY_TOKEN en .env antes de registrar el webhook.
+VERIFY_TOKEN = os.getenv("WHATSAPP_VERIFY_TOKEN", "inasc_whatsapp_verify_token")
+
+
+@router.get("/webhook/whatsapp")
+async def whatsapp_webhook_verify(
+    hub_mode: str = Query(default="", alias="hub.mode"),
+    hub_verify_token: str = Query(default="", alias="hub.verify_token"),
+    hub_challenge: str = Query(default="", alias="hub.challenge"),
+):
+    """
+    Endpoint de verificación del webhook — requerido por Meta.
+
+    Cuando registras el webhook en el Meta Developer Dashboard, Meta
+    envía un GET con estos parámetros para confirmar que el servidor
+    es el tuyo. El servidor debe responder con el hub.challenge como
+    texto plano (sin comillas, sin JSON).
+
+    Meta envía:
+        GET /webhook/whatsapp
+            ?hub.mode=subscribe
+            &hub.verify_token=TU_TOKEN
+            &hub.challenge=RETO_ALEATORIO
+
+    Respuesta esperada: el reto exacto como texto plano.
+    """
+    logger.info(
+        f"[WhatsApp] Solicitud de verificación de webhook — "
+        f"mode={hub_mode}, token_match={hub_verify_token == VERIFY_TOKEN}"
+    )
+
+    if hub_mode == "subscribe" and hub_verify_token == VERIFY_TOKEN:
+        logger.info("[WhatsApp] ✅ Webhook verificado exitosamente por Meta.")
+        # Meta requiere texto plano, NO JSON — respondemos el challenge directo
+        from fastapi.responses import PlainTextResponse
+        return PlainTextResponse(content=hub_challenge, status_code=200)
+
+    logger.warning(
+        "[WhatsApp] ❌ Verificación de webhook fallida. "
+        f"Token recibido: '{hub_verify_token}' | Token esperado: '{VERIFY_TOKEN}'"
+    )
+    raise HTTPException(status_code=403, detail="Verification token mismatch")
+
+
+@router.post("/webhook/whatsapp")
+async def whatsapp_webhook_receive(request: Request):
+    """
+    Endpoint que recibe los mensajes entrantes de WhatsApp via Meta webhook.
+
+    Flujo por cada update recibido:
+    1. Parsear el body JSON del update de Meta.
+    2. Verificar que contiene mensajes de texto (ignorar otros tipos).
+    3. WhatsAppProducer normaliza payload → IncomingMessage → Queue.
+    4. Responder 200 OK inmediatamente.
+       (Meta reintenta si no recibe 200 en < 20s)
+
+    IMPORTANTE: La respuesta al usuario se envía de forma asíncrona por
+    WhatsAppResponder en process_single_message() de main.py,
+    NO en este endpoint — mismo patrón que Telegram.
+    """
+    # --- 1. Parsear el body ---
+    try:
+        update: Dict[str, Any] = await request.json()
+    except Exception:
+        logger.warning("[WhatsApp] Body JSON inválido.")
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
+
+    logger.info(f"[WhatsApp] Update recibido: object={update.get('object')}")
+
+    # --- 2. Filtro rápido: ignorar notificaciones que no sean mensajes ---
+    # Meta también envía updates de estado (delivered, read) que no son mensajes
+    try:
+        entry = update.get("entry", [{}])[0]
+        change = entry.get("changes", [{}])[0].get("value", {})
+        if not change.get("messages"):
+            logger.info("[WhatsApp] Update sin mensajes (status update) — ignorado.")
+            return {"ok": True}
+    except (IndexError, KeyError):
+        logger.info("[WhatsApp] Update sin estructura de mensajes — ignorado.")
+        return {"ok": True}
+
+    # --- 3. Normalizar y enqueue ---
+    producer = WhatsAppProducer(tenant_id=WA_TENANT_ID)
+    try:
+        await producer.enqueue(update)
+    except ValueError as e:
+        # process_payload levanta ValueError para mensajes no-texto (fotos, audio)
+        logger.info(f"[WhatsApp] Mensaje descartado: {e}")
+
+    # --- 4. Responder 200 inmediatamente (Meta requiere < 20s) ---
+    return {"ok": True}

--- a/src/core/producers/whatsapp_producer.py
+++ b/src/core/producers/whatsapp_producer.py
@@ -1,0 +1,93 @@
+import logging
+import os
+from typing import Any
+
+from dotenv import load_dotenv
+
+from src.core.producers.base import BaseProducer
+from src.models.message import IncomingMessage
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+# tenant_id representa la EMPRESA (INASC S.A.S.), no el canal.
+# El canal queda en IncomingMessage.platform ('whatsapp').
+# Mismo patrón que TelegramProducer e WebSocketProducer.
+TENANT_ID = os.getenv("TENANT_ID", "inasc_001")
+
+
+class WhatsAppProducer(BaseProducer):
+    """
+    Producer para el canal WhatsApp (Meta Cloud API).
+
+    Recibe el payload JSON completo del webhook de Meta y lo normaliza
+    hacia el formato estándar IncomingMessage para que el Agent Loop
+    lo procese exactamente igual que Telegram o el Widget Web.
+
+    Estructura esperada del payload de Meta:
+    {
+      "object": "whatsapp_business_account",
+      "entry": [{
+        "changes": [{
+          "value": {
+            "messages": [{
+              "from": "573001234567",
+              "type": "text",
+              "text": {"body": "Hola, ¿qué productos tienen?"}
+            }],
+            "contacts": [{"profile": {"name": "Juan Pérez"}}]
+          }
+        }]
+      }]
+    }
+
+    Decisiones de diseño:
+    - platform_user_id = número de teléfono (E.164, sin '+'), que es el
+      identificador único del remitente y el destinatario de la respuesta.
+    - Solo se procesan mensajes de tipo 'text'. Fotos, audio, documentos
+      levantan ValueError para que el endpoint los ignore limpiamente.
+    - El tenant_id viene del entorno del servidor, nunca del payload de Meta.
+    """
+
+    def __init__(self, tenant_id: str = TENANT_ID):
+        self.tenant_id = tenant_id
+
+    async def process_payload(self, raw_payload: Any) -> IncomingMessage:
+        """
+        Mapea un update de Meta WhatsApp al modelo IncomingMessage.
+        Lanza ValueError si el mensaje no es de tipo texto.
+        """
+        try:
+            entry = raw_payload["entry"][0]
+            change = entry["changes"][0]["value"]
+            message = change["messages"][0]
+        except (KeyError, IndexError) as e:
+            raise ValueError(f"Payload de Meta malformado o sin mensajes: {e}")
+
+        msg_type = message.get("type")
+        if msg_type != "text":
+            raise ValueError(
+                f"Tipo de mensaje '{msg_type}' no soportado — ignorar "
+                "(audio, imagen, documento, etc.)"
+            )
+
+        phone_number = message["from"]  # E.164 sin '+', ej: "573001234567"
+        text_body = message["text"]["body"]
+
+        # Nombre del contacto (opcional — no siempre lo envía Meta)
+        contacts = change.get("contacts", [])
+        user_name = None
+        if contacts:
+            user_name = contacts[0].get("profile", {}).get("name")
+
+        logger.info(
+            f"[WhatsAppProducer] Mensaje de +{phone_number}: '{text_body[:60]}'"
+        )
+
+        return IncomingMessage(
+            platform="whatsapp",
+            platform_user_id=phone_number,
+            tenant_id=self.tenant_id,
+            content=text_body,
+            user_name=user_name,
+        )

--- a/src/core/whatsapp_responder.py
+++ b/src/core/whatsapp_responder.py
@@ -1,0 +1,104 @@
+import logging
+import os
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+# Credenciales de la Meta Cloud API — configurar en .env
+WHATSAPP_API_TOKEN = os.getenv("WHATSAPP_API_TOKEN", "")
+WHATSAPP_PHONE_NUMBER_ID = os.getenv("WHATSAPP_PHONE_NUMBER_ID", "")
+META_API_VERSION = "v19.0"
+META_API_URL = f"https://graph.facebook.com/{META_API_VERSION}"
+
+
+class WhatsAppResponder:
+    """
+    Singleton que envía respuestas al usuario vía Meta WhatsApp Cloud API.
+
+    Usa httpx.AsyncClient para no bloquear el Event Loop de FastAPI.
+    El cliente HTTP se inicializa con un timeout razonable y se reutiliza
+    durante toda la vida del servidor (patrón idéntico a TelegramResponder).
+
+    Endpoint Meta:
+        POST https://graph.facebook.com/v19.0/{PHONE_NUMBER_ID}/messages
+        Authorization: Bearer {WHATSAPP_API_TOKEN}
+        Content-Type: application/json
+
+    Body:
+        {
+          "messaging_product": "whatsapp",
+          "to": "{phone_number}",
+          "type": "text",
+          "text": { "body": "{message_text}" }
+        }
+    """
+
+    def __init__(self):
+        self._client = httpx.AsyncClient(timeout=15.0)
+
+    async def send_message(self, phone_number: str, text: str) -> bool:
+        """
+        Envía un mensaje de texto al número de WhatsApp dado.
+
+        Args:
+            phone_number: Número E.164 sin '+' (ej: "573001234567")
+            text:         Texto de la respuesta del agente
+
+        Returns:
+            True si Meta aceptó el mensaje (HTTP 200), False si hubo error.
+
+        Nota: Si WHATSAPP_API_TOKEN o WHATSAPP_PHONE_NUMBER_ID no están
+        configurados (modo desarrollo sin cuenta Meta), el método loguea un
+        aviso y retorna False sin lanzar excepción.
+        """
+        if not WHATSAPP_API_TOKEN or not WHATSAPP_PHONE_NUMBER_ID:
+            logger.warning(
+                "[WhatsAppResponder] WHATSAPP_API_TOKEN o WHATSAPP_PHONE_NUMBER_ID "
+                "no configurados. Respuesta NO enviada a WhatsApp "
+                f"(destino: +{phone_number}). "
+                "Configura las variables en .env para modo producción."
+            )
+            return False
+
+        url = f"{META_API_URL}/{WHATSAPP_PHONE_NUMBER_ID}/messages"
+        headers = {
+            "Authorization": f"Bearer {WHATSAPP_API_TOKEN}",
+            "Content-Type": "application/json",
+        }
+        payload = {
+            "messaging_product": "whatsapp",
+            "to": phone_number,
+            "type": "text",
+            "text": {"body": text},
+        }
+
+        try:
+            response = await self._client.post(url, json=payload, headers=headers)
+            response.raise_for_status()
+            logger.info(
+                f"[WhatsAppResponder] ✅ Mensaje enviado a +{phone_number}. "
+                f"Meta message_id: {response.json().get('messages', [{}])[0].get('id', 'N/A')}"
+            )
+            return True
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                f"[WhatsAppResponder] ❌ Error HTTP {e.response.status_code} "
+                f"enviando a +{phone_number}: {e.response.text}"
+            )
+            return False
+        except httpx.RequestError as e:
+            logger.error(
+                f"[WhatsAppResponder] ❌ Error de red enviando a +{phone_number}: {e}"
+            )
+            return False
+
+    async def close(self):
+        """Cierra el cliente HTTP limpiamente al apagar el servidor."""
+        await self._client.aclose()
+        logger.info("[WhatsAppResponder] HTTP client closed.")
+
+
+# Instancia global Singleton — importar en main.py
+whatsapp_responder = WhatsAppResponder()

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from src.core.queue_manager import queue_manager
 from src.core.connection_manager import connection_manager
 from src.core.telegram_responder import telegram_responder
+from src.core.whatsapp_responder import whatsapp_responder
 from src.core.llm import llm_engine
 from src.database.connection import async_session_factory
 from src.database import crud
@@ -64,8 +65,10 @@ async def process_single_message(message):
         # Otros canales futuros: añadir elif aquí (WhatsApp, Signal, etc.)
         if message.platform == "telegram":
             await telegram_responder.send_message(message.platform_user_id, response_text)
+        elif message.platform == "whatsapp":
+            await whatsapp_responder.send_message(message.platform_user_id, response_text)
         else:
-            # Fallback para WebSocket y futuros canales con cola asyncio
+            # Canal web (WebSocket) y futuros canales con cola asyncio
             await connection_manager.send_to_client(message.platform_user_id, response_text)
         
     except Exception as e:
@@ -109,8 +112,9 @@ async def lifespan(app: FastAPI):
         await agent_task
     except asyncio.CancelledError:
         pass
-    # Cerrar el cliente HTTP de TelegramResponder limpiamente
+    # Cerrar los clientes HTTP limpiamente al apagar el servidor
     await telegram_responder.close()
+    await whatsapp_responder.close()
 
 # Initialize FastAPI with the lifespan context manager
 app = FastAPI(
@@ -124,9 +128,11 @@ app = FastAPI(
 from src.api.routers import simulator
 from src.api.routers import websocket
 from src.api.routers import telegram
+from src.api.routers import whatsapp
 app.include_router(simulator.router)
 app.include_router(websocket.router)
 app.include_router(telegram.router)
+app.include_router(whatsapp.router)
 
 # Servir archivos estáticos del Widget JS (Issue #15)
 # Ruta relativa al propio main.py → src/static/ → expuesta en /static

--- a/tests/functional/test_whatsapp_webhook.py
+++ b/tests/functional/test_whatsapp_webhook.py
@@ -1,0 +1,175 @@
+"""
+Tests funcionales para el WebHook de WhatsApp (Issue #16).
+
+Usan TestClient de FastAPI / Starlette para simular requests HTTP reales
+al endpoint /webhook/whatsapp sin necesitar credenciales de Meta.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+
+# ── Fixtures ────────────────────────────────────────────────────────
+
+@pytest.fixture
+def client():
+    """
+    Cliente de prueba con mocks preventivos para evitar efectos secundarios.
+
+    Los responders (telegram, whatsapp) se pasan como AsyncMock con .close
+    explícitamente awaitable porque lifespan hace `await responder.close()`
+    al apagar el servidor.
+    """
+    from unittest.mock import MagicMock, AsyncMock
+
+    tg_mock = MagicMock()
+    tg_mock.close = AsyncMock()
+    wa_mock = MagicMock()
+    wa_mock.close = AsyncMock()
+
+    with (
+        patch("src.main.run_agent_loop", new_callable=AsyncMock),
+        patch("src.main.llm_engine"),
+        patch("src.main.async_session_factory"),
+        patch("src.main.telegram_responder", tg_mock),
+        patch("src.main.whatsapp_responder", wa_mock),
+    ):
+        from src.main import app
+        with TestClient(app, raise_server_exceptions=True) as c:
+            yield c
+
+
+
+def _meta_update(phone: str = "573001234567", text: str = "Hola!", name: str | None = "Test User") -> dict:
+    contacts = [{"profile": {"name": name}}] if name else []
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [{
+                        "from": phone,
+                        "type": "text",
+                        "text": {"body": text},
+                    }],
+                    "contacts": contacts,
+                }
+            }]
+        }]
+    }
+
+
+# ── Tests: GET /webhook/whatsapp (verificación Meta) ────────────────
+
+def test_verificacion_webhook_token_correcto(client):
+    """Meta verifica el webhook con token correcto → responde el challenge exacto."""
+    params = {
+        "hub.mode": "subscribe",
+        "hub.verify_token": "inasc_whatsapp_verify_token",
+        "hub.challenge": "1234567890",
+    }
+    response = client.get("/webhook/whatsapp", params=params)
+    assert response.status_code == 200
+    assert response.text == "1234567890"
+
+
+def test_verificacion_webhook_token_incorrecto(client):
+    """Token equivocado → 403 Forbidden."""
+    params = {
+        "hub.mode": "subscribe",
+        "hub.verify_token": "token_equivocado",
+        "hub.challenge": "1234567890",
+    }
+    response = client.get("/webhook/whatsapp", params=params)
+    assert response.status_code == 403
+
+
+def test_verificacion_webhook_mode_incorrecto(client):
+    """hub.mode distinto de 'subscribe' → 403."""
+    params = {
+        "hub.mode": "unsubscribe",
+        "hub.verify_token": "inasc_whatsapp_verify_token",
+        "hub.challenge": "9876543210",
+    }
+    response = client.get("/webhook/whatsapp", params=params)
+    assert response.status_code == 403
+
+
+# ── Tests: POST /webhook/whatsapp (mensajes entrantes) ──────────────
+
+def test_post_mensaje_texto_encola_y_responde_ok(client):
+    """Un mensaje de texto válido debe ser encolado y el endpoint retorna 200 OK."""
+    with patch("src.api.routers.whatsapp.WhatsAppProducer") as MockProducer:
+        mock_instance = AsyncMock()
+        MockProducer.return_value = mock_instance
+
+        response = client.post("/webhook/whatsapp", json=_meta_update())
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        mock_instance.enqueue.assert_awaited_once()
+
+
+def test_post_update_de_estado_ignorado(client):
+    """Updates de tipo 'status' (delivered/read) deben ignorarse → 200 sin encolar."""
+    status_update = {
+        "object": "whatsapp_business_account",
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "statuses": [{"id": "msg_id", "status": "delivered"}]
+                    # Sin campo "messages"
+                }
+            }]
+        }]
+    }
+    with patch("src.api.routers.whatsapp.WhatsAppProducer") as MockProducer:
+        mock_instance = AsyncMock()
+        MockProducer.return_value = mock_instance
+
+        response = client.post("/webhook/whatsapp", json=status_update)
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        mock_instance.enqueue.assert_not_awaited()
+
+
+def test_post_mensaje_no_texto_descartado(client):
+    """Un mensaje de imagen/audio → WhatsAppProducer levanta ValueError → ignorado con 200."""
+    img_update = {
+        "object": "whatsapp_business_account",
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [{"from": "573001234567", "type": "image"}],
+                    "contacts": [],
+                }
+            }]
+        }]
+    }
+    with patch("src.api.routers.whatsapp.WhatsAppProducer") as MockProducer:
+        mock_instance = AsyncMock()
+        mock_instance.enqueue.side_effect = ValueError("image no soportado")
+        MockProducer.return_value = mock_instance
+
+        response = client.post("/webhook/whatsapp", json=img_update)
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+
+def test_post_body_json_invalido(client):
+    """Un body que no es JSON válido retorna 400."""
+    response = client.post(
+        "/webhook/whatsapp",
+        content=b"no soy json",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 400
+
+
+def test_post_no_modifica_canales_existentes(client):
+    """El endpoint de Telegram sigue funcionando — no hay regresiones."""
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json()["status"] == "online"

--- a/tests/unit/test_whatsapp_producer.py
+++ b/tests/unit/test_whatsapp_producer.py
@@ -1,0 +1,120 @@
+"""
+Tests unitarios para WhatsAppProducer.
+
+Estructura idéntica a test_telegram_producer.py para consistencia.
+No se necesita servidor real ni credenciales de Meta.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+from src.core.producers.whatsapp_producer import WhatsAppProducer
+
+
+# ── Helpers ────────────────────────────────────────────────────────
+
+def _make_payload(
+    phone: str = "573001234567",
+    text: str = "Hola, ¿qué productos tienen?",
+    name: str | None = "Juan Pérez",
+    msg_type: str = "text",
+) -> dict:
+    """Construye un payload de Meta Cloud API mínimo pero válido."""
+    message: dict = {"from": phone, "type": msg_type}
+    if msg_type == "text":
+        message["text"] = {"body": text}
+
+    contacts = [{"profile": {"name": name}}] if name else []
+
+    return {
+        "object": "whatsapp_business_account",
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [message],
+                    "contacts": contacts,
+                }
+            }]
+        }]
+    }
+
+
+# ── Tests ───────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_process_payload_campos_completos():
+    """El producer extrae correctamente todos los campos del payload de Meta."""
+    producer = WhatsAppProducer(tenant_id="inasc_001")
+    payload = _make_payload(
+        phone="573001234567",
+        text="Necesito calibrar un equipo.",
+        name="Ana Gómez",
+    )
+    msg = await producer.process_payload(payload)
+
+    assert msg.platform == "whatsapp"
+    assert msg.platform_user_id == "573001234567"
+    assert msg.content == "Necesito calibrar un equipo."
+    assert msg.user_name == "Ana Gómez"
+    assert msg.tenant_id == "inasc_001"
+
+
+@pytest.mark.asyncio
+async def test_process_payload_sin_nombre_contacto():
+    """El campo user_name es None cuando Meta no envía datos de contacto."""
+    producer = WhatsAppProducer(tenant_id="inasc_001")
+    payload = _make_payload(phone="573009876543", text="¿Tienen balanzas?", name=None)
+    msg = await producer.process_payload(payload)
+
+    assert msg.platform_user_id == "573009876543"
+    assert msg.user_name is None
+    assert msg.content == "¿Tienen balanzas?"
+
+
+@pytest.mark.asyncio
+async def test_process_payload_tenant_id_inyectado_por_productor():
+    """El tenant_id viene del servidor, NUNCA del payload de Meta."""
+    producer = WhatsAppProducer(tenant_id="inasc_tenant_test")
+    payload = _make_payload()
+    msg = await producer.process_payload(payload)
+
+    assert msg.tenant_id == "inasc_tenant_test"
+
+
+@pytest.mark.asyncio
+async def test_process_payload_mensaje_no_texto_lanza_error():
+    """Un mensaje de tipo 'image', 'audio' etc. debe levantar ValueError."""
+    producer = WhatsAppProducer(tenant_id="inasc_001")
+    payload = _make_payload(msg_type="image")
+
+    with pytest.raises(ValueError, match="no soportado"):
+        await producer.process_payload(payload)
+
+
+@pytest.mark.asyncio
+async def test_enqueue_llama_queue_manager():
+    """enqueue() normaliza el payload y lo deposita en el QueueManager."""
+    producer = WhatsAppProducer(tenant_id="inasc_001")
+    payload = _make_payload(phone="573001111111", text="Cotización por favor.")
+
+    with patch("src.core.producers.base.queue_manager") as mock_qm:
+        mock_qm.enqueue_message = AsyncMock()
+        await producer.enqueue(payload)
+        mock_qm.enqueue_message.assert_awaited_once()
+        enqueued_msg = mock_qm.enqueue_message.call_args[0][0]
+        assert enqueued_msg.platform == "whatsapp"
+        assert enqueued_msg.platform_user_id == "573001111111"
+        assert enqueued_msg.content == "Cotización por favor."
+
+
+@pytest.mark.asyncio
+async def test_enqueue_mensaje_no_texto_no_encola():
+    """Un mensaje de imagen no debe ser encolado — enqueue debe silenciarlo."""
+    producer = WhatsAppProducer(tenant_id="inasc_001")
+    payload = _make_payload(msg_type="audio")
+
+    with patch("src.core.producers.base.queue_manager") as mock_qm:
+        mock_qm.enqueue_message = AsyncMock()
+        # enqueue llama process_payload internamente; si lanza ValueError,
+        # el router lo captura y no lo encola. Verificamos que ValueError se propaga.
+        with pytest.raises(ValueError):
+            await producer.enqueue(payload)
+        mock_qm.enqueue_message.assert_not_awaited()


### PR DESCRIPTION
## Descripción

Implementa el canal WhatsApp (Issue #16) usando Meta WhatsApp Cloud API con el mismo patrón Producer-Consumer ya implementado para Telegram (#5) y el Widget Web (#14).

## Archivos nuevos

| Archivo | Descripción |
|---|---|
| `src/core/producers/whatsapp_producer.py` | `WhatsAppProducer` — normaliza payload Meta → `IncomingMessage`. Solo texto; tipos no soportados (imagen, audio) lanzan `ValueError` |
| `src/core/whatsapp_responder.py` | `WhatsAppResponder` singleton con `httpx.AsyncClient`. Degrada graciosamente si no hay credenciales Meta configuradas |
| `src/api/routers/whatsapp.py` | `GET /webhook/whatsapp` — challenge/response Meta (respuesta PlainText); `POST /webhook/whatsapp` — recibe mensajes, ignora status updates |
| `tests/unit/test_whatsapp_producer.py` | 6 tests unitarios del producer |
| `tests/functional/test_whatsapp_webhook.py` | 8 tests funcionales del webhook |

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `src/main.py` | `elif platform == "whatsapp"` en ruteo + `whatsapp_responder.close()` en lifespan + router registrado |
| `.env.example` | `WHATSAPP_API_TOKEN`, `WHATSAPP_PHONE_NUMBER_ID`, `WHATSAPP_VERIFY_TOKEN` documentadas |

## Verificación

- ✅ **14/14 tests pasan** (6 unit + 8 funcionales)
- ✅ `GET /webhook/whatsapp` responde el challenge en PlainText (requerido por Meta)
- ✅ `POST /webhook/whatsapp` encola mensajes de texto, ignora status updates y tipos no-texto
- ✅ `WhatsAppResponder` no bloquea el servidor sin credenciales (warning en log, retorna `False`)
- ⏳ Verificación end-to-end pendiente de registro en Meta Developer Dashboard + credenciales reales

## Notas técnicas

- El `WHATSAPP_VERIFY_TOKEN` por defecto es `inasc_whatsapp_verify_token` — cambiar en `.env` antes de registrar el webhook en Meta.
- El `platform_user_id` es el número E.164 sin `+` (ej: `"573001234567"`), que es el identificador del destinatario para la respuesta.

Closes #16