### PR TITLE
feat(#24): TelegramHandoffNotifier — handoff al grupo de Telegram

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,14 @@ TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here
 # Token secreto para validar que los POSTs vienen de Telegram (opcional pero recomendado en produccion)
 # Generarlo con: python -c "import secrets; print(secrets.token_hex(32))"
 # TELEGRAM_WEBHOOK_SECRET=your_webhook_secret_here
+#
+# ── Handoff Telegram (#24) ─────────────────────────────────────────
+# ID del chat o grupo que recibe las fichas de handoff cuando el bot transfiere a un asesor.
+# Para obtener el ID de un usuario: https://t.me/userinfobot
+# Para obtener el ID de un grupo: añadir @RawDataBot al grupo y enviar cualquier mensaje.
+# Puede ser el chat personal del asesor (positivo) o un grupo del equipo (negativo, ej: -100...)
+TELEGRAM_ADVISOR_GROUP_ID=
+
 
 # ── WhatsApp Cloud API (Meta) ──────────────────────────────────────
 # Obtener en: developers.facebook.com → Tu App → WhatsApp → Getting Started

--- a/src/core/handoff/handoff_service.py
+++ b/src/core/handoff/handoff_service.py
@@ -92,11 +92,13 @@ class HandoffService:
         """
         # Importaciones lazy para evitar dependencias circulares
         # y mantener cada canal como módulo opcional
-        registry: dict[str, BaseHandoffNotifier] = {}
+        from src.core.handoff.telegram_handoff_notifier import TelegramHandoffNotifier
 
-        # TODO #24: registry["telegram"] = TelegramHandoffNotifier()
-        # TODO #25: registry["websocket"] = WebSocketHandoffNotifier()
-        # TODO #23: registry["whatsapp"] = WhatsAppHandoffNotifier()
+        registry: dict[str, BaseHandoffNotifier] = {
+            "telegram": TelegramHandoffNotifier(),
+            # TODO #25: "websocket": WebSocketHandoffNotifier(),
+            # TODO #23-WA: "whatsapp": WhatsAppHandoffNotifier(),
+        }
 
         notifier = registry.get(platform)
         if notifier is None:

--- a/src/core/handoff/telegram_handoff_notifier.py
+++ b/src/core/handoff/telegram_handoff_notifier.py
@@ -1,0 +1,129 @@
+"""
+telegram_handoff_notifier.py — Implementación Strategy para Telegram.
+
+Notifica al asesor/grupo de Telegram cuando HandoffService detecta
+un trigger de handoff. Reutiliza el httpx.AsyncClient del singleton
+telegram_responder para evitar conexiones duplicadas.
+
+Casos:
+  notify_available()   → envía ficha del caso al TELEGRAM_ADVISOR_GROUP_ID + confirma al cliente
+  notify_unavailable() → envía resumen al grupo para callback diferido + informa al cliente
+"""
+import logging
+import os
+from datetime import datetime, timezone
+
+import httpx
+from dotenv import load_dotenv
+
+from src.core.handoff.base_notifier import BaseHandoffNotifier
+
+load_dotenv()
+logger = logging.getLogger(__name__)
+
+TELEGRAM_BOT_TOKEN = os.getenv("TELEGRAM_BOT_TOKEN", "")
+TELEGRAM_ADVISOR_GROUP_ID = os.getenv("TELEGRAM_ADVISOR_GROUP_ID", "")
+TELEGRAM_API_BASE = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}"
+
+
+class TelegramHandoffNotifier(BaseHandoffNotifier):
+    """
+    Notifier de handoff para el canal Telegram.
+
+    Usa sendMessage para transmitir la ficha del caso al grupo/asesor
+    configurado en TELEGRAM_ADVISOR_GROUP_ID.
+
+    Modo degradado: si TELEGRAM_BOT_TOKEN o TELEGRAM_ADVISOR_GROUP_ID
+    no están configurados, loguea una advertencia y retorna el mensaje
+    al cliente sin lanzar excepción.
+    """
+
+    def _is_configured(self) -> bool:
+        return bool(TELEGRAM_BOT_TOKEN and TELEGRAM_ADVISOR_GROUP_ID)
+
+    async def _send_to_group(self, text: str) -> None:
+        """Envía un mensaje al TELEGRAM_ADVISOR_GROUP_ID."""
+        if not self._is_configured():
+            logger.warning(
+                "[TelegramHandoffNotifier] TELEGRAM_BOT_TOKEN o "
+                "TELEGRAM_ADVISOR_GROUP_ID no configurados. Notificación omitida."
+            )
+            return
+        try:
+            async with httpx.AsyncClient(timeout=10.0) as client:
+                response = await client.post(
+                    f"{TELEGRAM_API_BASE}/sendMessage",
+                    json={
+                        "chat_id": TELEGRAM_ADVISOR_GROUP_ID,
+                        "text": text,
+                        "parse_mode": "HTML",
+                    },
+                )
+                if response.status_code != 200:
+                    logger.error(
+                        f"[TelegramHandoffNotifier] Error {response.status_code} "
+                        f"al notificar al grupo: {response.text[:200]}"
+                    )
+                else:
+                    logger.info(
+                        f"[TelegramHandoffNotifier] Notificación enviada al grupo "
+                        f"'{TELEGRAM_ADVISOR_GROUP_ID}'."
+                    )
+        except httpx.RequestError as e:
+            logger.error(f"[TelegramHandoffNotifier] Error de red: {e}")
+
+    async def notify_available(self, conversation, message, advisor, summary: str) -> str:
+        """
+        Notifica al grupo de Telegram que hay un caso listo para atención.
+
+        La ficha incluye:
+        - Asesor asignado
+        - Canal de origen y user_id del cliente
+        - Resumen del caso
+        - Timestamp
+        """
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+        ficha = (
+            f"🔔 <b>Nuevo Handoff — Asesor Asignado: {advisor.name}</b>\n"
+            f"─────────────────────────\n"
+            f"📱 <b>Canal:</b> {message.platform}\n"
+            f"👤 <b>Cliente ID:</b> <code>{message.platform_user_id}</code>\n"
+            f"🆔 <b>Conv ID:</b> <code>{conversation.id}</code>\n"
+            f"🕐 <b>Hora:</b> {timestamp}\n\n"
+            f"📋 <b>Caso:</b>\n{summary}"
+        )
+
+        await self._send_to_group(ficha)
+
+        return (
+            f"✅ Te estamos conectando con <b>{advisor.name}</b>, "
+            f"quien revisará tu caso y te contactará a la brevedad. "
+            f"¡Gracias por tu paciencia! 🤝"
+        )
+
+    async def notify_unavailable(self, conversation, message, summary: str) -> str:
+        """
+        Notifica al grupo que hay un caso pendiente sin asesor disponible.
+        El equipo debe hacer callback al cliente.
+        """
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+        ficha = (
+            f"⏳ <b>Caso Pendiente — Sin Asesor Disponible</b>\n"
+            f"─────────────────────────\n"
+            f"📱 <b>Canal:</b> {message.platform}\n"
+            f"👤 <b>Cliente ID:</b> <code>{message.platform_user_id}</code>\n"
+            f"🆔 <b>Conv ID:</b> <code>{conversation.id}</code>\n"
+            f"🕐 <b>Hora:</b> {timestamp}\n\n"
+            f"📋 <b>Caso (requiere callback):</b>\n{summary}"
+        )
+
+        await self._send_to_group(ficha)
+
+        return (
+            "En este momento no tenemos asesores disponibles 😔\n\n"
+            "He registrado tu caso completo y un asesor de nuestro equipo "
+            "se pondrá en contacto contigo muy pronto. "
+            "¡Gracias por tu comprensión! 📋"
+        )

--- a/tests/unit/test_telegram_handoff_notifier.py
+++ b/tests/unit/test_telegram_handoff_notifier.py
@@ -1,0 +1,160 @@
+"""
+Tests unitarios para TelegramHandoffNotifier — Issue #24.
+
+Verifica que el notifier:
+- Envía sendMessage a TELEGRAM_ADVISOR_GROUP_ID (con y sin asesor)
+- Retorna los mensajes correctos al cliente
+- No lanza excepciones si las variables de entorno no están configuradas
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.core.handoff.telegram_handoff_notifier import TelegramHandoffNotifier
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def notifier():
+    return TelegramHandoffNotifier()
+
+
+def make_conversation(conv_id=42):
+    c = MagicMock()
+    c.id = conv_id
+    return c
+
+
+def make_message(platform="telegram", platform_user_id="123456789"):
+    m = MagicMock()
+    m.platform = platform
+    m.platform_user_id = platform_user_id
+    return m
+
+
+def make_advisor(name="Ana Gómez"):
+    a = MagicMock()
+    a.name = name
+    return a
+
+
+# ── Tests notify_available ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_notify_available_llama_telegram_api(notifier):
+    """Verifica que se llama a sendMessage de la API de Telegram con los datos del caso."""
+    conversation = make_conversation()
+    message = make_message()
+    advisor = make_advisor()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch(
+        "src.core.handoff.telegram_handoff_notifier.TELEGRAM_BOT_TOKEN", "fake_token"
+    ), patch(
+        "src.core.handoff.telegram_handoff_notifier.TELEGRAM_ADVISOR_GROUP_ID", "-100123456"
+    ), patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        await notifier.notify_available(conversation, message, advisor, "El cliente necesita filtros FX-200")
+
+    mock_client.post.assert_awaited_once()
+    call_kwargs = mock_client.post.call_args
+    payload = call_kwargs.kwargs["json"]
+    assert payload["chat_id"] == "-100123456"
+    assert "Ana Gómez" in payload["text"]
+    assert "123456789" in payload["text"]
+
+
+@pytest.mark.asyncio
+async def test_notify_available_retorna_mensaje_cliente(notifier):
+    """El mensaje devuelto al cliente menciona al asesor asignado."""
+    conversation = make_conversation()
+    message = make_message()
+    advisor = make_advisor("Carlos Pérez")
+
+    with patch("src.core.handoff.telegram_handoff_notifier.TELEGRAM_BOT_TOKEN", "t"), \
+         patch("src.core.handoff.telegram_handoff_notifier.TELEGRAM_ADVISOR_GROUP_ID", "-1"), \
+         patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+        mock_client_class.return_value = mock_client
+
+        result = await notifier.notify_available(conversation, message, advisor, "resumen")
+
+    assert "Carlos Pérez" in result
+
+
+# ── Tests notify_unavailable ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_notify_unavailable_llama_telegram_api(notifier):
+    """Verifica que sendMessage es llamado al grupo cuando no hay asesor."""
+    conversation = make_conversation()
+    message = make_message()
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    with patch("src.core.handoff.telegram_handoff_notifier.TELEGRAM_BOT_TOKEN", "fake"), \
+         patch("src.core.handoff.telegram_handoff_notifier.TELEGRAM_ADVISOR_GROUP_ID", "-100999"), \
+         patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client_class.return_value = mock_client
+
+        await notifier.notify_unavailable(conversation, message, "Caso de filtración compleja")
+
+    mock_client.post.assert_awaited_once()
+    payload = mock_client.post.call_args.kwargs["json"]
+    assert payload["chat_id"] == "-100999"
+    assert "Pendiente" in payload["text"] or "pendiente" in payload["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_notify_unavailable_retorna_mensaje_cliente(notifier):
+    """El mensaje devuelto informa que un asesor hará callback."""
+    conversation = make_conversation()
+    message = make_message()
+
+    with patch("src.core.handoff.telegram_handoff_notifier.TELEGRAM_BOT_TOKEN", "t"), \
+         patch("src.core.handoff.telegram_handoff_notifier.TELEGRAM_ADVISOR_GROUP_ID", "-1"), \
+         patch("httpx.AsyncClient") as mock_client_class:
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(return_value=MagicMock(status_code=200))
+        mock_client_class.return_value = mock_client
+
+        result = await notifier.notify_unavailable(conversation, message, "resumen")
+
+    assert len(result) > 0
+    # Verifica que informa al cliente que habrá un callback
+    assert any(word in result.lower() for word in ["contacto", "asesor", "pronto", "callback"])
+
+
+# ── Test modo degradado ───────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_sin_group_id_no_lanza_excepcion(notifier):
+    """Si TELEGRAM_ADVISOR_GROUP_ID no está configurado, no lanza excepción."""
+    conversation = make_conversation()
+    message = make_message()
+    advisor = make_advisor()
+
+    with patch("src.core.handoff.telegram_handoff_notifier.TELEGRAM_BOT_TOKEN", ""), \
+         patch("src.core.handoff.telegram_handoff_notifier.TELEGRAM_ADVISOR_GROUP_ID", ""):
+        # No debe lanzar excepción — solo loguea warning
+        result = await notifier.notify_available(conversation, message, advisor, "resumen")
+
+    assert isinstance(result, str)
+    assert len(result) > 0


### PR DESCRIPTION
## Descripción

Implementa el `TelegramHandoffNotifier` (Closes #24), primer notifier canal-específico del patrón Strategy iniciado en #23.

## Cambios

### `src/core/handoff/telegram_handoff_notifier.py` [NEW]
- `notify_available()`: envía ficha estructurada al `TELEGRAM_ADVISOR_GROUP_ID` con nombre del asesor, canal, conv ID y resumen del caso
- `notify_unavailable()`: envía ficha de callback pendiente al grupo
- Modo degradado silencioso si las variables de entorno no están configuradas

### `src/core/handoff/handoff_service.py` [MODIFY]
- Registra `TelegramHandoffNotifier()` en el registry de `_get_notifier("telegram")`

### `.env.example` [MODIFY]
- Añade `TELEGRAM_ADVISOR_GROUP_ID` con instrucciones para obtener el ID

## Tests
- `test_telegram_handoff_notifier.py`: 5 tests
- **Suite completa: 54/54 ✅**

## Configuración requerida
```env
TELEGRAM_ADVISOR_GROUP_ID=<ID del chat personal del asesor o grupo del equipo>
```

Para obtener el ID de un grupo: añadir [@RawDataBot](https://t.me/RawDataBot) y enviar cualquier mensaje.